### PR TITLE
Update to support new slack apps

### DIFF
--- a/checker.py
+++ b/checker.py
@@ -156,9 +156,6 @@ def send_slack_notification(notification_text, error=True):
     json_message = {
         'token': SLACK_TOKEN,
         'channel': SLACK_CHANNEL,
-        'as_user': 'false',
-        'icon_emoji': ':computer:',
-        'username': 'Prometheus Monitor',
         'text': slack_text
     }
 

--- a/checker.py
+++ b/checker.py
@@ -163,7 +163,8 @@ def send_slack_notification(notification_text, error=True):
     }
 
     try:
-        requests.post('https://slack.com/api/chat.postMessage', json_message)
+        slack_response = requests.post('https://slack.com/api/chat.postMessage', json_message)
+        slack_response.raise_for_status()
     except requests.RequestException as err:
         logger.error('Post to Slack API encountered an error')
         logger.error(err, exc_info=True)

--- a/checker.py
+++ b/checker.py
@@ -165,6 +165,12 @@ def send_slack_notification(notification_text, error=True):
     try:
         slack_response = requests.post('https://slack.com/api/chat.postMessage', json_message)
         slack_response.raise_for_status()
+
+        if not slack_response.json()["ok"]:
+            print('Received an error from slack!')
+            print(slack_response.text)
+            raise requests.RequestException
+
     except requests.RequestException as err:
         logger.error('Post to Slack API encountered an error')
         logger.error(err, exc_info=True)

--- a/checker.py
+++ b/checker.py
@@ -164,8 +164,8 @@ def send_slack_notification(notification_text, error=True):
         slack_response.raise_for_status()
 
         if not slack_response.json()["ok"]:
-            print('Received an error from slack!')
-            print(slack_response.text)
+            logger.error('Received an error from slack!')
+            logger.error(slack_response.text)
             raise requests.RequestException
 
     except requests.RequestException as err:


### PR DESCRIPTION
Calls to slack with the `as_user` field set will silently fail if you are using a "new" style slack API token. This PR removes the redundant fields and improves logging and error detection